### PR TITLE
Add insufficient liquidity message for swap

### DIFF
--- a/src/lang/en/index.ts
+++ b/src/lang/en/index.ts
@@ -99,6 +99,7 @@ export default {
     networkFee: 'Network Fee',
     networkFeeTooltip: 'Network fee is used to ensure SORA system\'s growth and stable performance.',
     insufficientAmount: 'Insufficient {tokenSymbol} amount',
+    insufficientLiquidity: 'Insufficient liquidity for this trade',
     confirmSwap: 'Confirm swap',
     swapOutputMessage: 'Output is estimated. You will receive <span class="min-received-label">at least</span> {transactionValue} or the transaction will revert.'
   },


### PR DESCRIPTION
# Task

[PSS-420]: WEB UI. Not have error "Insufficient liquidity for this trade."

## Changes

1. Add message for insufficient liquidity.

## Author

Signed-off-by: Stefan <popov@soramitsu.co.jp>

[PSS-420]: https://soramitsu.atlassian.net/browse/PSS-420