### PR TITLE
PSS-416: add watcher for slippageTolerance in Swap.vue

### DIFF
--- a/src/components/Swap.vue
+++ b/src/components/Swap.vue
@@ -294,7 +294,6 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, InputFo
       } else {
         try {
           const swapResult = await api.getSwapResult(this.tokenFrom.address, this.tokenTo.address, this.formModel.from)
-          console.log('swapResult', swapResult)
           this.formModel.to = swapResult.amount
           this.setLiquidityProviderFee(swapResult.fee)
           const minMaxReceived = await api.getMinMaxValue(this.tokenFrom.address, this.tokenTo.address, swapResult.amount, this.slippageTolerance)
@@ -335,7 +334,6 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, InputFo
           // Always use getSwapResult and minMaxReceived with reversed flag for Token B
           const isExchangeBSwap = true
           const swapResult = await api.getSwapResult(this.tokenFrom.address, this.tokenTo.address, this.formModel.to, isExchangeBSwap)
-          console.log('swapResult', swapResult)
           this.formModel.from = swapResult.amount
           this.setLiquidityProviderFee(swapResult.fee)
           const minMaxReceived = await api.getMinMaxValue(this.tokenFrom.address, this.tokenTo.address, swapResult.amount, this.slippageTolerance, isExchangeBSwap)

--- a/src/components/Swap.vue
+++ b/src/components/Swap.vue
@@ -104,7 +104,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator'
+import { Component, Mixins, Watch } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
 import { api } from '@soramitsu/soraneo-wallet-web'
 import { KnownSymbols, FPNumber } from '@sora-substrate/util'
@@ -145,6 +145,11 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, InputFo
   @Action setNetworkFee
   @Action('getPrices', { namespace: 'prices' }) getPrices
   @Action('resetPrices', { namespace: 'prices' }) resetPrices
+
+  @Watch('slippageTolerance')
+  private handleSlippageToleranceChange (): void {
+    this.recountSwapValues()
+  }
 
   inputPlaceholder: string = formatNumber(0, 1)
   isTokenFromBalanceAvailable = false
@@ -289,6 +294,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, InputFo
       } else {
         try {
           const swapResult = await api.getSwapResult(this.tokenFrom.address, this.tokenTo.address, this.formModel.from)
+          console.log('swapResult', swapResult)
           this.formModel.to = swapResult.amount
           this.setLiquidityProviderFee(swapResult.fee)
           const minMaxReceived = await api.getMinMaxValue(this.tokenFrom.address, this.tokenTo.address, swapResult.amount, this.slippageTolerance)
@@ -329,6 +335,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, InputFo
           // Always use getSwapResult and minMaxReceived with reversed flag for Token B
           const isExchangeBSwap = true
           const swapResult = await api.getSwapResult(this.tokenFrom.address, this.tokenTo.address, this.formModel.to, isExchangeBSwap)
+          console.log('swapResult', swapResult)
           this.formModel.from = swapResult.amount
           this.setLiquidityProviderFee(swapResult.fee)
           const minMaxReceived = await api.getMinMaxValue(this.tokenFrom.address, this.tokenTo.address, swapResult.amount, this.slippageTolerance, isExchangeBSwap)


### PR DESCRIPTION
# Task

[PSS-416](https://soramitsu.atlassian.net/browse/PSS-416): WEB UI. Incorrect calculate Minimum received.

## Changes

1. Added a watcher for `slippageTolerance `to a `Swap.vue`, to recalculate `minMaxRecieved `value after `slippageTolerance `change

## Author

Signed-off-by: Nikita-Polyakov<polyakov@soramitsu.co.jp>

[PSS-416]: https://soramitsu.atlassian.net/browse/PSS-416