### PR TITLE
PSS-486: reset swap values in vuex after transaction

### DIFF
--- a/src/components/Swap.vue
+++ b/src/components/Swap.vue
@@ -462,6 +462,8 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin) {
     if (isSwapConfirmed) {
       this.resetFieldFrom()
       this.resetFieldTo()
+      this.setToValue('')
+      this.setFromValue('')
       this.setTokenFromPrice(true)
       this.resetPrices()
       this.isFieldFromActive = false


### PR DESCRIPTION
# Task

[PSS-486](https://soramitsu.atlassian.net/browse/PSS-486): WEB UI. Previous data is memorable in input field.

## Author

Signed-off-by: Nikita-Polyakov <polyakov@soramitsu.co.jp>

[PSS-486]: https://soramitsu.atlassian.net/browse/PSS-486