### PR TITLE
PSS-351: Show balance in select token dialog

### DIFF
--- a/src/components/SelectToken.vue
+++ b/src/components/SelectToken.vue
@@ -37,13 +37,12 @@
 <script lang="ts">
 import { Component, Mixins, Prop } from 'vue-property-decorator'
 import { Action, Getter } from 'vuex-class'
-import { KnownAssets, KnownSymbols, Asset, AccountAsset } from '@sora-substrate/util'
+import { Asset, AccountAsset } from '@sora-substrate/util'
 
 import TranslationMixin from '@/components/mixins/TranslationMixin'
 import DialogMixin from '@/components/mixins/DialogMixin'
 import LoadingMixin from '@/components/mixins/LoadingMixin'
 import DialogBase from '@/components/DialogBase.vue'
-import { Token } from '@/types'
 import { Components } from '@/consts'
 import { lazyComponent } from '@/router'
 

--- a/src/components/SelectToken.vue
+++ b/src/components/SelectToken.vue
@@ -57,9 +57,9 @@ const namespace = 'assets'
 })
 export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, LoadingMixin) {
   query = ''
-  selectedToken: Token | null = null
+  selectedToken: AccountAsset | null = null
 
-  @Prop({ default: () => null, type: Object }) readonly asset!: Token
+  @Prop({ default: () => null, type: Object }) readonly asset!: Asset
   @Prop({ default: () => false, type: Boolean }) readonly accountAssetsOnly!: boolean
   @Prop({ default: () => false, type: Boolean }) readonly notNullBalanceOnly!: boolean
 
@@ -79,7 +79,7 @@ export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, L
   get assetsList (): Array<AccountAsset> {
     const { asset, assets, accountAssetsHashTable, notNullBalanceOnly, accountAssetsOnly } = this
 
-    return assets.reduce((result: Array<AccountAsset>, item) => {
+    return assets.reduce((result: Array<AccountAsset>, item: Asset) => {
       if (!item || (asset && item.address === asset.address)) return result
 
       const accountAsset = accountAssetsHashTable[item.address]
@@ -121,7 +121,7 @@ export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, L
     }
   }
 
-  selectToken (token: Token): void {
+  selectToken (token: AccountAsset): void {
     this.selectedToken = token
     this.query = ''
     this.$emit('select', token)

--- a/src/components/SelectToken.vue
+++ b/src/components/SelectToken.vue
@@ -69,19 +69,26 @@ export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, L
   @Getter('accountAssets') accountAssets!: Array<AccountAsset>
   @Action('getAccountAssets') getAccountAssets
 
+  get accountAssetsHashTable () {
+    return this.accountAssets.reduce((result, item) => ({
+      ...result,
+      [item.address]: item
+    }), {})
+  }
+
   get assetsList (): Array<AccountAsset> {
-    const { asset, assets, accountAssets, notNullBalanceOnly, accountAssetsOnly } = this
+    const { asset, assets, accountAssetsHashTable, notNullBalanceOnly, accountAssetsOnly } = this
 
     return assets.reduce((result: Array<AccountAsset>, item) => {
-      if (asset && item.address === asset.address) return result
+      if (!item || (asset && item.address === asset.address)) return result
 
-      const accountAsset = accountAssets.find(a => a.address === item.address)
+      const accountAsset = accountAssetsHashTable[item.address]
 
       if (accountAssetsOnly && !accountAsset) return result
 
       const accountBalance = Number(accountAsset?.balance) || 0
 
-      if (notNullBalanceOnly && (!Number.isFinite(accountBalance) || accountBalance <= 0)) return result
+      if (notNullBalanceOnly && accountBalance <= 0) return result
 
       const prepared = {
         ...item,
@@ -95,10 +102,11 @@ export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, L
   get filteredTokens (): Array<AccountAsset> {
     if (this.query) {
       const query = this.query.toLowerCase().trim()
+
       return this.assetsList.filter(t =>
         this.t(`assetNames.${t.symbol}`).toLowerCase().includes(query) ||
-        t.symbol.toLowerCase().includes(query) ||
-        t.address.toLowerCase().includes(query)
+        t.symbol?.toLowerCase?.()?.includes?.(query) ||
+        t.address?.toLowerCase?.()?.includes?.(query)
       )
     }
 

--- a/src/components/Swap.vue
+++ b/src/components/Swap.vue
@@ -270,7 +270,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin) {
   }
 
   async getNetworkFee (): Promise<void> {
-    const networkFee = await api.getSwapNetworkFee(this.tokenFrom.address, this.tokenTo.address, this.formModel.from, this.formModel.to, this.slippageTolerance, this.isExchangeB)
+    const networkFee = await api.getSwapNetworkFee(this.tokenFrom?.address, this.tokenTo?.address, this.formModel.from, this.formModel.to, this.slippageTolerance, this.isExchangeB)
     this.setNetworkFee(networkFee)
   }
 


### PR DESCRIPTION
# Task

[PSS-351](https://soramitsu.atlassian.net/browse/PSS-351): WEB UI. Select token. Token balance is not displayed.

## Changes

1. Refactored an `assetsList ` computed property to return an array of objects `AccountAsset ` type, that have a `balance `property

## Author

Signed-off-by: Nikita-Polyakov <polyakov@soramitsu.co.jp>

[PSS-351]: https://soramitsu.atlassian.net/browse/PSS-351