### PR TITLE
PSS-351 Select Token fixes

### DIFF
--- a/src/components/SelectToken.vue
+++ b/src/components/SelectToken.vue
@@ -89,13 +89,13 @@ export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, L
 
       if (accountAssetsOnly && !accountAsset) return result
 
-      const accountBalance = Number(accountAsset?.balance) || 0
+      const balance = accountAsset?.balance
 
-      if (notNullBalanceOnly && accountBalance <= 0) return result
+      if (notNullBalanceOnly && (!balance || +balance <= 0)) return result
 
       const prepared = {
         ...item,
-        balance: String(accountBalance)
+        balance
       } as AccountAsset
 
       return [...result, prepared]

--- a/src/components/SelectToken.vue
+++ b/src/components/SelectToken.vue
@@ -139,7 +139,8 @@ export default class SelectToken extends Mixins(TranslationMixin, DialogMixin, L
   }
 
   formatBalance (token: AccountAsset): string {
-    if (!token.balance) {
+    // show "-" with 0 balance too
+    if (!token.balance || +token.balance === 0) {
       return '-'
     }
     return this.formatCodecNumber(token.balance, token.decimals)

--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -159,8 +159,8 @@
       </div>
     </info-card>
 
-    <select-token :visible.sync="showSelectFirstTokenDialog" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstToken" />
-    <select-token :visible.sync="showSelectSecondTokenDialog" :asset="firstToken" @select="setSecondToken" />
+    <select-token :visible.sync="showSelectFirstTokenDialog" :connected="connected" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstToken" />
+    <select-token :visible.sync="showSelectSecondTokenDialog" :connected="connected" :asset="firstToken" @select="setSecondToken" />
 
     <confirm-token-pair-dialog
       :visible.sync="showConfirmDialog"

--- a/src/views/CreatePair.vue
+++ b/src/views/CreatePair.vue
@@ -158,8 +158,8 @@
       </template>
     </template>
 
-    <select-token :visible.sync="showSelectFirstTokenDialog" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstToken" />
-    <select-token :visible.sync="showSelectSecondTokenDialog" :asset="firstToken" @select="setSecondToken" />
+    <select-token :visible.sync="showSelectFirstTokenDialog" :connected="connected" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstToken" />
+    <select-token :visible.sync="showSelectSecondTokenDialog" :connected="connected" :asset="firstToken" @select="setSecondToken" />
 
     <confirm-token-pair-dialog
       :visible.sync="showConfirmDialog"


### PR DESCRIPTION
# Task

[PSS-351]: WEB UI. Select token. Token balance is not displayed.

## Changes

1. Show "0" balance as "-" (following design)
2. Pass `connected ` props to all SelectToken components

## Author

Signed-off-by: Nikita-Polyakov <polyakov@soramitsu.co.jp>

[PSS-351]: https://soramitsu.atlassian.net/browse/PSS-351