### PR TITLE
PSS-516: WEB UI. Can go to remove liquidity page without liquidity on account

### DIFF
--- a/src/components/PageNotFound.vue
+++ b/src/components/PageNotFound.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="container">
+    <h3>{{ t('pageNotFound.title') }}</h3>
+    <h2>{{ t('pageNotFound.body') }}</h2>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator'
+import TranslationMixin from '@/components/mixins/TranslationMixin'
+
+@Component
+export default class PageNotFound extends Mixins(TranslationMixin) {}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  h2 {
+    margin-top: .25em;
+    font-size: 3rem;
+    color: var(--s-color-theme-accent);
+  }
+}
+</style>

--- a/src/components/Pool.vue
+++ b/src/components/Pool.vue
@@ -36,10 +36,16 @@
             <div class="pool-info-value">{{ getPoolShare(liquidityItem) }}%</div>
           </div> -->
           <div class="pool-info--buttons">
-            <s-button type="primary" size="small" @click="handleAddPairLiquidity(liquidityItem.firstAddress, liquidityItem.secondAddress)">
+            <s-button type="primary" size="small" @click="handleAddPairLiquidity(
+              getAssetSymbol(liquidityItem.firstAddress).toLowerCase(),
+              getAssetSymbol(liquidityItem.secondAddress).toLowerCase())"
+            >
               {{ t('pool.addLiquidity') }}
             </s-button>
-            <s-button type="primary" size="small" @click="handleRemoveLiquidity(liquidityItem.firstAddress, liquidityItem.secondAddress)">
+            <s-button type="primary" size="small" @click="handleRemoveLiquidity(
+              getAssetSymbol(liquidityItem.firstAddress).toLowerCase(),
+              getAssetSymbol(liquidityItem.secondAddress).toLowerCase())"
+            >
               {{ t('pool.removeLiquidity') }}
             </s-button>
           </div>
@@ -99,6 +105,11 @@ export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberF
     return isWalletConnected()
   }
 
+  getAssetSymbol (address): string {
+    const asset = this.assets.find(a => a.address === address)
+    return asset ? asset.symbol : 'Unknown asset'
+  }
+
   handleAddLiquidity (): void {
     router.push({ name: PageNames.AddLiquidity })
   }
@@ -107,12 +118,12 @@ export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberF
     router.push({ name: PageNames.CreatePair })
   }
 
-  handleAddPairLiquidity (firstAddress, secondAddress): void {
-    router.push({ name: PageNames.AddLiquidityId, params: { firstAddress, secondAddress } })
+  handleAddPairLiquidity (firstSymbol, secondSymbol): void {
+    router.push({ name: PageNames.AddLiquidityId, params: { firstSymbol, secondSymbol } })
   }
 
-  handleRemoveLiquidity (firstAddress, secondAddress): void {
-    router.push({ name: PageNames.RemoveLiquidity, params: { firstAddress, secondAddress } })
+  handleRemoveLiquidity (firstSymbol, secondSymbol): void {
+    router.push({ name: PageNames.RemoveLiquidity, params: { firstSymbol, secondSymbol } })
   }
 
   handleConnectWallet (): void {
@@ -124,11 +135,6 @@ export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberF
       return `${firstToken}-${secondToken}`
     }
     return ''
-  }
-
-  getAssetSymbol (address) {
-    const asset = this.assets.find(a => a.address === address)
-    return asset ? asset.symbol : 'Unknown asset'
   }
 
   getFirstBalance (liquidityItem: AccountLiquidity): string {

--- a/src/components/Pool.vue
+++ b/src/components/Pool.vue
@@ -101,7 +101,7 @@ export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberF
 
   getAssetSymbol (address): string {
     const asset = this.assets.find(a => a.address === address)
-    return asset ? asset.symbol : 'Unknown asset'
+    return asset ? asset.symbol : this.t('pool.unknownAsset')
   }
 
   handleAddLiquidity (): void {

--- a/src/components/Pool.vue
+++ b/src/components/Pool.vue
@@ -36,16 +36,10 @@
             <div class="pool-info-value">{{ getPoolShare(liquidityItem) }}%</div>
           </div> -->
           <div class="pool-info--buttons">
-            <s-button type="primary" size="small" @click="handleAddPairLiquidity(
-              getAssetSymbol(liquidityItem.firstAddress).toLowerCase(),
-              getAssetSymbol(liquidityItem.secondAddress).toLowerCase())"
-            >
+            <s-button type="primary" size="small" @click="handleAddPairLiquidity(liquidityItem.firstAddress, liquidityItem.secondAddress)">
               {{ t('pool.addLiquidity') }}
             </s-button>
-            <s-button type="primary" size="small" @click="handleRemoveLiquidity(
-              getAssetSymbol(liquidityItem.firstAddress).toLowerCase(),
-              getAssetSymbol(liquidityItem.secondAddress).toLowerCase())"
-            >
+            <s-button type="primary" size="small" @click="handleRemoveLiquidity(liquidityItem.firstAddress, liquidityItem.secondAddress)">
               {{ t('pool.removeLiquidity') }}
             </s-button>
           </div>
@@ -118,12 +112,12 @@ export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberF
     router.push({ name: PageNames.CreatePair })
   }
 
-  handleAddPairLiquidity (firstSymbol, secondSymbol): void {
-    router.push({ name: PageNames.AddLiquidityId, params: { firstSymbol, secondSymbol } })
+  handleAddPairLiquidity (firstAddress, secondAddress): void {
+    router.push({ name: PageNames.AddLiquidityId, params: { firstAddress, secondAddress } })
   }
 
-  handleRemoveLiquidity (firstSymbol, secondSymbol): void {
-    router.push({ name: PageNames.RemoveLiquidity, params: { firstSymbol, secondSymbol } })
+  handleRemoveLiquidity (firstAddress, secondAddress): void {
+    router.push({ name: PageNames.RemoveLiquidity, params: { firstAddress, secondAddress } })
   }
 
   handleConnectWallet (): void {

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -13,7 +13,8 @@ export enum PageNames {
   CreatePair = 'CreatePair',
   AddLiquidity = 'AddLiquidity',
   AddLiquidityId = 'AddLiquidityId',
-  RemoveLiquidity = 'RemoveLiquidity'
+  RemoveLiquidity = 'RemoveLiquidity',
+  PageNotFound = 'PageNotFound'
 }
 
 // TODO: Add InfoLine component to the list of components

--- a/src/lang/en/index.ts
+++ b/src/lang/en/index.ts
@@ -21,7 +21,8 @@ export default {
     [PageNames.CreatePair]: 'Create Pair',
     [PageNames.AddLiquidity]: 'Add Liquidity',
     [PageNames.AddLiquidityId]: 'Add Liquidity',
-    [PageNames.RemoveLiquidity]: 'Remove Liquidity'
+    [PageNames.RemoveLiquidity]: 'Remove Liquidity',
+    [PageNames.PageNotFound]: 'Page Not Found'
   },
   mainMenu: {
     [PageNames.Exchange]: 'Exchange',
@@ -45,6 +46,10 @@ export default {
       [Operation.RemoveLiquidity]: 'Failed to remove {amount} {symbol} and {amount2} {symbol2}',
       [Operation.CreatePair]: 'Failed to supply {amount} {symbol} and {amount2} {symbol2}'
     }
+  },
+  pageNotFound: {
+    title: 'Page not found',
+    body: '404'
   },
   about: {
     polkaswapText: 'Polkaswap - decentralised token exchange for Polkadot ecosystem. Swap any token on SORA, add liquidity, create exchanges, earn through passive market making, build decentralized price feeds.',

--- a/src/lang/en/index.ts
+++ b/src/lang/en/index.ts
@@ -120,6 +120,7 @@ export default {
     pairTokens: '{pair} Pool Tokens',
     poolShare: 'Your pool share',
     comingSoon: 'Coming soon',
+    unknownAsset: 'Unknown asset',
     description: 'When you add liquidity, you are given pool tokens representing your position. These tokens automaticaly earn fees proportional to your share of the pool, and can be redeemed at any time.'
   },
   selectToken: {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -51,7 +51,7 @@ const routes: Array<RouteConfig> = [
     meta: { requiresAuth: true }
   },
   {
-    path: '/exchange/pool/add/:firstSymbol-:secondSymbol',
+    path: '/exchange/pool/add/:firstAddress/:secondAddress',
     name: PageNames.AddLiquidityId,
     component: lazyView(PageNames.AddLiquidity),
     meta: { requiresAuth: true }
@@ -63,7 +63,7 @@ const routes: Array<RouteConfig> = [
     meta: { requiresAuth: true }
   },
   {
-    path: '/exchange/pool/remove/:firstSymbol-:secondSymbol',
+    path: '/exchange/pool/remove/:firstAddress/:secondAddress',
     name: PageNames.RemoveLiquidity,
     component: lazyView(PageNames.RemoveLiquidity),
     meta: { requiresAuth: true }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -47,22 +47,26 @@ const routes: Array<RouteConfig> = [
   {
     path: '/exchange/pool/create-pair',
     name: PageNames.CreatePair,
-    component: lazyView(PageNames.CreatePair)
+    component: lazyView(PageNames.CreatePair),
+    meta: { requiresAuth: true }
   },
   {
-    path: '/exchange/pool/add/:firstAddress/:secondAddress',
+    path: '/exchange/pool/add/:firstSymbol-:secondSymbol',
     name: PageNames.AddLiquidityId,
-    component: lazyView(PageNames.AddLiquidity)
+    component: lazyView(PageNames.AddLiquidity),
+    meta: { requiresAuth: true }
   },
   {
     path: '/exchange/pool/add',
     name: PageNames.AddLiquidity,
-    component: lazyView(PageNames.AddLiquidity)
+    component: lazyView(PageNames.AddLiquidity),
+    meta: { requiresAuth: true }
   },
   {
-    path: '/exchange/pool/remove/:firstAddress/:secondAddress',
+    path: '/exchange/pool/remove/:firstSymbol-:secondSymbol',
     name: PageNames.RemoveLiquidity,
-    component: lazyView(PageNames.RemoveLiquidity)
+    component: lazyView(PageNames.RemoveLiquidity),
+    meta: { requiresAuth: true }
   },
   {
     path: '/stats',
@@ -71,12 +75,33 @@ const routes: Array<RouteConfig> = [
   {
     path: '/support',
     name: PageNames.Support
+  },
+  {
+    path: '*',
+    redirect: '/exchange'
+    // TODO: Turn on redirect to PageNotFound
+    // name: PageNames.PageNotFound,
+    // component: lazyComponent(PageNames.PageNotFound)
   }
 ]
 
 const router = new VueRouter({
   mode: 'history',
   routes
+})
+
+router.beforeEach((to, from, next) => {
+  if (to.matched.some(record => record.meta.requiresAuth)) {
+    if (!(localStorage.getItem('sora.name') && localStorage.getItem('sora.address'))) {
+      next({
+        name: PageNames.Wallet
+      })
+    } else {
+      next()
+    }
+  } else {
+    next()
+  }
 })
 
 export default router

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import VueRouter, { RouteConfig } from 'vue-router'
 
 import { PageNames } from '@/consts'
+import { isWalletConnected } from '@/utils'
 
 Vue.use(VueRouter)
 
@@ -92,7 +93,7 @@ const router = new VueRouter({
 
 router.beforeEach((to, from, next) => {
   if (to.matched.some(record => record.meta.requiresAuth)) {
-    if (!(localStorage.getItem('sora.name') && localStorage.getItem('sora.address'))) {
+    if (!isWalletConnected()) {
       next({
         name: PageNames.Wallet
       })

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -157,6 +157,9 @@
       @if $isChooseTokenDisabled == true {
         cursor: default;
       } @else {
+        &:hover, &:active {
+          cursor: pointer;
+        }
         &:hover, &:active, &:focus {
           background-color: var(--s-color-base-background-hover);
           border-color: var(--s-color-base-background-hover);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,11 @@ export const isXorAccountAsset = (asset: Asset | AccountAsset): boolean => {
   return asset ? asset.symbol === KnownSymbols.XOR : false
 }
 
+export const getAssetAddressBySymbol = (assets: Array<Asset | AccountAsset>, symbol: string): string => {
+  const asset = assets.find(a => a?.symbol === symbol)
+  return asset ? asset?.address : ''
+}
+
 export const isMaxButtonAvailable = (areAssetsSelected: boolean, asset: AccountAsset, amount: string | number, fee: CodecString): boolean => {
   if (!isWalletConnected() || !areAssetsSelected || +asset.balance === 0) {
     return false

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,11 +10,6 @@ export const isXorAccountAsset = (asset: Asset | AccountAsset): boolean => {
   return asset ? asset.symbol === KnownSymbols.XOR : false
 }
 
-export const getAssetAddressBySymbol = (assets: Array<Asset | AccountAsset>, symbol: string): string => {
-  const asset = assets.find(a => a?.symbol === symbol)
-  return asset ? asset?.address : ''
-}
-
 export const isMaxButtonAvailable = (areAssetsSelected: boolean, asset: AccountAsset, amount: string | number, fee: CodecString): boolean => {
   if (!isWalletConnected() || !areAssetsSelected || +asset.balance === 0) {
     return false

--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -66,9 +66,9 @@
               type="tertiary"
               size="small"
               border-radius="medium"
-              :icon="!hasSecondAddress ? 'chevron-bottom-rounded' : undefined"
+              :icon="!secondAddress ? 'chevron-bottom-rounded' : undefined"
               icon-position="right"
-              @click="!hasSecondAddress ? openSelectSecondTokenDialog() : undefined"
+              @click="!secondAddress ? openSelectSecondTokenDialog() : undefined"
             >
               <token-logo :token="secondToken" size="small" />
               {{ secondToken.symbol }}
@@ -196,7 +196,6 @@ import CreateTokenPairMixin from '@/components/mixins/TokenPairMixin'
 
 import router, { lazyComponent } from '@/router'
 import { Components, PageNames } from '@/consts'
-import { getAssetAddressBySymbol } from '@/utils'
 
 const namespace = 'addLiquidity'
 
@@ -217,30 +216,24 @@ export default class AddLiquidity extends Mixins(TokenPairMixin) {
   @Getter('isNotFirstLiquidityProvider', { namespace }) isNotFirstLiquidityProvider!: boolean
   @Getter('shareOfPool', { namespace }) shareOfPool!: string
   @Getter('accountLiquidity', { namespace: 'pool' }) accountLiquidity!: Array<AccountLiquidity>
-  @Getter('assets', { namespace: 'assets' }) assets
 
   @Action('setDataFromLiquidity', { namespace }) setDataFromLiquidity
   @Action('addLiquidity', { namespace }) addLiquidity
   @Action('resetFocusedField', { namespace }) resetFocusedField
-  @Action('getAssets', { namespace: 'assets' }) getAssets
 
   get firstAddress (): string {
-    return getAssetAddressBySymbol(this.assets, this.$route.params.firstSymbol?.toUpperCase())
+    return this.$route.params.firstAddress
   }
 
   get secondAddress (): string {
-    return getAssetAddressBySymbol(this.assets, this.$route.params.secondSymbol?.toUpperCase())
-  }
-
-  get hasSecondAddress (): string {
-    return this.$route.params.secondSymbol
+    return this.$route.params.secondAddress
   }
 
   get computedClasses (): string {
     const componentClass = 'input-container'
     const classes = [componentClass, componentClass + '--second']
 
-    if (this.$route.params.secondSymbol) {
+    if (this.secondAddress) {
       classes.push(`${componentClass}--disabled-select`)
     }
 
@@ -273,7 +266,6 @@ export default class AddLiquidity extends Mixins(TokenPairMixin) {
   }
 
   async afterApiConnect (): Promise<void> {
-    await this.getAssets()
     if (this.firstAddress && this.secondAddress) {
       await this.setDataFromLiquidity({
         firstAddress: this.firstAddress,
@@ -281,7 +273,7 @@ export default class AddLiquidity extends Mixins(TokenPairMixin) {
       })
     }
     // If user don't have the liquidity (navigated through the address bar) redirect to the Pool page
-    if (this.$route.params.firstSymbol && this.$route.params.secondSymbol && !this.liquidityInfo) {
+    if (this.firstAddress && this.secondAddress && !this.liquidityInfo) {
       router.push({ name: PageNames.Pool })
     }
   }

--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -36,7 +36,7 @@
         </div>
       </div>
       <s-icon class="icon-divider" name="plus-rounded" size="medium" />
-      <div class="input-container">
+      <div :class="computedClasses">
         <div class="input-line">
           <div class="input-title">
             <span>{{ t('createPair.deposit') }}</span>
@@ -61,7 +61,15 @@
             <s-button v-if="isSecondMaxButtonAvailable" class="el-button--max" type="tertiary" size="small" border-radius="mini" @click="handleMaxValue(secondToken, setSecondTokenValue)">
               {{ t('exchange.max') }}
             </s-button>
-            <s-button class="el-button--choose-token" type="tertiary" size="small" border-radius="medium" icon="chevron-bottom-rounded" icon-position="right" @click="openSelectSecondTokenDialog">
+            <s-button
+              class="el-button--choose-token"
+              type="tertiary"
+              size="small"
+              border-radius="medium"
+              :icon="!hasSecondAddress ? 'chevron-bottom-rounded' : undefined"
+              icon-position="right"
+              @click="!hasSecondAddress ? openSelectSecondTokenDialog() : undefined"
+            >
               <token-logo :token="secondToken" size="small" />
               {{ secondToken.symbol }}
             </s-button>
@@ -224,6 +232,21 @@ export default class AddLiquidity extends Mixins(TokenPairMixin) {
     return getAssetAddressBySymbol(this.assets, this.$route.params.secondSymbol?.toUpperCase())
   }
 
+  get hasSecondAddress (): string {
+    return this.$route.params.secondSymbol
+  }
+
+  get computedClasses (): string {
+    const componentClass = 'input-container'
+    const classes = [componentClass, componentClass + '--second']
+
+    if (this.$route.params.secondSymbol) {
+      classes.push(`${componentClass}--disabled-select`)
+    }
+
+    return classes.join(' ')
+  }
+
   get liquidityInfo () {
     return this.accountLiquidity.find(l => l.firstAddress === this.firstToken?.address && l.secondAddress === this.secondToken?.address)
   }
@@ -297,8 +320,13 @@ export default class AddLiquidity extends Mixins(TokenPairMixin) {
 <style lang="scss" scoped>
 .el-form--actions {
   @include input-form-styles;
-  @include buttons;
   @include full-width-button;
+}
+.input-container {
+  @include buttons(true);
+  &--second:not(.input-container--disabled-select) {
+    @include buttons();
+  }
 }
 @include vertical-divider;
 @include vertical-divider('el-divider');

--- a/src/views/RemoveLiquidity.vue
+++ b/src/views/RemoveLiquidity.vue
@@ -156,6 +156,7 @@ import NumberFormatterMixin from '@/components/mixins/NumberFormatterMixin'
 
 import router, { lazyComponent } from '@/router'
 import { Components, PageNames } from '@/consts'
+import { getAssetAddressBySymbol } from '@/utils'
 
 const namespace = 'removeLiquidity'
 
@@ -185,6 +186,7 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
   @Getter('secondTokenAmount', { namespace }) secondTokenAmount!: any
   @Getter('secondTokenBalance', { namespace }) secondTokenBalance!: CodecString
   @Getter('fee', { namespace }) fee!: CodecString
+  @Getter('assets', { namespace: 'assets' }) assets
   @Getter('xorBalance', { namespace: 'assets' }) xorBalance!: any
   @Getter('xorAsset', { namespace: 'assets' }) xorAsset!: any
   @Getter('price', { namespace: 'prices' }) price!: string
@@ -213,9 +215,13 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
     await this.withApi(async () => {
       await this.getAssets()
       await this.getLiquidity({
-        firstAddress: this.firstTokenAddress,
-        secondAddress: this.secondTokenAddress
+        firstAddress: getAssetAddressBySymbol(this.assets, this.$route.params.firstSymbol?.toUpperCase()),
+        secondAddress: getAssetAddressBySymbol(this.assets, this.$route.params.secondSymbol?.toUpperCase())
       })
+      // If user don't have the liquidity (navigated through the address bar) redirect to the Pool page
+      if (!this.liquidity) {
+        router.push({ name: PageNames.Pool })
+      }
     })
     this.sliderDragButton = this.$el.querySelector('.slider-container .el-slider__button')
     this.sliderInput = this.$el.querySelector('.s-input--remove-part .el-input__inner')
@@ -233,11 +239,11 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
   isWalletConnected = true
 
   get firstTokenAddress (): string {
-    return this.$route.params.firstAddress
+    return getAssetAddressBySymbol(this.assets, this.$route.params.firstSymbol?.toUpperCase())
   }
 
   get secondTokenAddress (): string {
-    return this.$route.params.secondAddress
+    return getAssetAddressBySymbol(this.assets, this.$route.params.secondSymbol?.toUpperCase())
   }
 
   // TODO: could be reused from TokenPairMixin

--- a/src/views/RemoveLiquidity.vue
+++ b/src/views/RemoveLiquidity.vue
@@ -156,7 +156,6 @@ import NumberFormatterMixin from '@/components/mixins/NumberFormatterMixin'
 
 import router, { lazyComponent } from '@/router'
 import { Components, PageNames } from '@/consts'
-import { getAssetAddressBySymbol } from '@/utils'
 
 const namespace = 'removeLiquidity'
 
@@ -186,7 +185,6 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
   @Getter('secondTokenAmount', { namespace }) secondTokenAmount!: any
   @Getter('secondTokenBalance', { namespace }) secondTokenBalance!: CodecString
   @Getter('fee', { namespace }) fee!: CodecString
-  @Getter('assets', { namespace: 'assets' }) assets
   @Getter('xorBalance', { namespace: 'assets' }) xorBalance!: any
   @Getter('xorAsset', { namespace: 'assets' }) xorAsset!: any
   @Getter('price', { namespace: 'prices' }) price!: string
@@ -215,8 +213,8 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
     await this.withApi(async () => {
       await this.getAssets()
       await this.getLiquidity({
-        firstAddress: getAssetAddressBySymbol(this.assets, this.$route.params.firstSymbol?.toUpperCase()),
-        secondAddress: getAssetAddressBySymbol(this.assets, this.$route.params.secondSymbol?.toUpperCase())
+        firstAddress: this.firstTokenAddress,
+        secondAddress: this.secondTokenAddress
       })
       // If user don't have the liquidity (navigated through the address bar) redirect to the Pool page
       if (!this.liquidity) {
@@ -239,11 +237,11 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
   isWalletConnected = true
 
   get firstTokenAddress (): string {
-    return getAssetAddressBySymbol(this.assets, this.$route.params.firstSymbol?.toUpperCase())
+    return this.$route.params.firstAddress
   }
 
   get secondTokenAddress (): string {
-    return getAssetAddressBySymbol(this.assets, this.$route.params.secondSymbol?.toUpperCase())
+    return this.$route.params.secondAddress
   }
 
   // TODO: could be reused from TokenPairMixin

--- a/src/views/RemoveLiquidity.vue
+++ b/src/views/RemoveLiquidity.vue
@@ -216,11 +216,12 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
         firstAddress: this.firstTokenAddress,
         secondAddress: this.secondTokenAddress
       })
-      // If user don't have the liquidity (navigated through the address bar) redirect to the Pool page
-      if (!this.liquidity) {
-        router.push({ name: PageNames.Pool })
-      }
     })
+    // If user don't have the liquidity (navigated through the address bar) redirect to the Pool page
+    if (!this.liquidity) {
+      router.push({ name: PageNames.Pool })
+      return
+    }
     this.sliderDragButton = this.$el.querySelector('.slider-container .el-slider__button')
     this.sliderInput = this.$el.querySelector('.s-input--remove-part .el-input__inner')
     if (this.sliderDragButton) {


### PR DESCRIPTION
# Task

[PSS-516]: WEB UI. Can go to remove liquidity page without liquidity on account.

## Changes

1. Added Page Not Found Draft.
2. Fixed Add and Remove Liquidity router bags.
3. Hid some screens for unauthorized access.
4. Added redirect to exchange for Page Not Found error.
5. Disabled selects for existed liquidity addition.

## Author

Signed-off-by: alexnatalia <alekseenko@soramitsu.co.jp>

[PSS-516]: https://soramitsu.atlassian.net/browse/PSS-516