### PR TITLE
Fix/pss 539 metamsk lock issue

### DIFF
--- a/src/store/web3.ts
+++ b/src/store/web3.ts
@@ -92,8 +92,11 @@ const getters = {
 
 const mutations = {
   [types.RESET] (state) {
+    // we shouldn't reset networks, setted from env
+    const networkSettingsKeys = ['soraNetwork', 'defaultEthNetwork']
     const s = initialState()
-    Object.keys(s).forEach(key => {
+
+    Object.keys(s).filter(key => !networkSettingsKeys.includes(key)).forEach(key => {
       state[key] = s[key]
     })
   },

--- a/src/utils/web3-util.ts
+++ b/src/utils/web3-util.ts
@@ -147,9 +147,22 @@ async function onConnectWallet (url = 'https://cloudflare-eth.com'): Promise<str
     rpc: { 1: url }
   })
   await provider.enable()
-  const web3Instance = new Web3(provider)
-  const accounts = await web3Instance.eth.getAccounts()
-  return accounts.length ? accounts[0] : ''
+
+  const account = await getAccount()
+
+  return account
+}
+
+async function getAccount (): Promise<string> {
+  try {
+    const web3Instance = await getInstance()
+    const accounts = await web3Instance.eth.getAccounts()
+
+    return accounts.length ? accounts[0] : ''
+  } catch (error) {
+    console.error(error)
+    return ''
+  }
 }
 
 async function getInstance (): Promise<Web3> {
@@ -168,12 +181,15 @@ async function watchEthereum (cb: {
   onDisconnect: Function;
 }) {
   const ethereum = (window as any).ethereum
+
   if (ethereum) {
     ethereum.on('accountsChanged', cb.onAccountChange)
     ethereum.on('chainChanged', cb.onNetworkChange)
   }
+
+  await getInstance()
+
   if (provider) {
-    provider.on('accountsChanged', cb.onAccountChange)
     provider.on('disconnect', cb.onDisconnect)
   }
 }
@@ -256,6 +272,7 @@ async function executeContractMethod ({
 
 export default {
   onConnect,
+  getAccount,
   storeEthUserAddress,
   getEthUserAddress,
   storeEthNetwork,


### PR DESCRIPTION
# Task

[PSS-539]: Ethereum bridge. Ethereum transaction failes if Metamask is logged out

## Changes

When user locks his account on MetaMask extension, the[ ` _handleUnlockStateChanged`](https://github.com/MetaMask/inpage-provider/blob/main/src/MetaMaskInpageProvider.ts#L265) from metamask/inpage-provider should be called, and then 'accountsChanged' event should be emitted. But this happens only once during extension lifecycle (this is an extension bug)

For now, the check that account is connected added. This check can be removed after https://github.com/MetaMask/metamask-extension/issues/10368 will be resolved

## Author

Signed-off-by: Nikita-Polyakov <polyakov@soramitsu.co.jp>

[PSS-539]: https://soramitsu.atlassian.net/browse/PSS-539