### PR TITLE
Fix/pss 539 handle account lock

### DIFF
--- a/src/components/mixins/WalletConnectMixin.ts
+++ b/src/components/mixins/WalletConnectMixin.ts
@@ -68,9 +68,19 @@ export default class WalletConnectMixin extends Mixins(TranslationMixin) {
     }
   }
 
+  async checkConnectionToExternalAccount (func: Function): Promise<void> {
+    const connected = await this.checkExternalAccountIsConnected()
+
+    if (!connected) {
+      await this.connectExternalWallet()
+    } else {
+      await func()
+    }
+  }
+
   // TODO: remove this check, when MetaMask issue will be resolved
   // https://github.com/MetaMask/metamask-extension/issues/10368
-  async checkExternalAccountIsConnected (): Promise<boolean> {
+  private async checkExternalAccountIsConnected (): Promise<boolean> {
     const account = await web3Util.getAccount()
 
     return !!account && account.toLowerCase() === this.ethAddress.toLowerCase()

--- a/src/components/mixins/WalletConnectMixin.ts
+++ b/src/components/mixins/WalletConnectMixin.ts
@@ -80,7 +80,7 @@ export default class WalletConnectMixin extends Mixins(TranslationMixin) {
 
   // TODO: remove this check, when MetaMask issue will be resolved
   // https://github.com/MetaMask/metamask-extension/issues/10368
-  private async checkExternalAccountIsConnected (): Promise<boolean> {
+  async checkExternalAccountIsConnected (): Promise<boolean> {
     const account = await web3Util.getAccount()
 
     return !!account && account.toLowerCase() === this.ethAddress.toLowerCase()

--- a/src/components/mixins/WalletConnectMixin.ts
+++ b/src/components/mixins/WalletConnectMixin.ts
@@ -69,20 +69,12 @@ export default class WalletConnectMixin extends Mixins(TranslationMixin) {
   }
 
   async checkConnectionToExternalAccount (func: Function): Promise<void> {
-    const connected = await this.checkExternalAccountIsConnected()
+    const connected = await web3Util.checkAccountIsConnected(this.ethAddress)
 
     if (!connected) {
       await this.connectExternalWallet()
     } else {
       await func()
     }
-  }
-
-  // TODO: remove this check, when MetaMask issue will be resolved
-  // https://github.com/MetaMask/metamask-extension/issues/10368
-  async checkExternalAccountIsConnected (): Promise<boolean> {
-    const account = await web3Util.getAccount()
-
-    return !!account && account.toLowerCase() === this.ethAddress.toLowerCase()
   }
 }

--- a/src/lang/en/index.ts
+++ b/src/lang/en/index.ts
@@ -242,7 +242,7 @@ export default {
     },
     status: {
       pending: '{step} transactions pending...',
-      failed: '{step} transactions failed. @:retryText.',
+      failed: '{step} transactions failed. @:(retryText).',
       confirm: 'Confirm 2nd of 2 transactions...',
       complete: 'Complete',
       convertionComplete: 'Conversion complete'

--- a/src/lang/en/index.ts
+++ b/src/lang/en/index.ts
@@ -274,7 +274,8 @@ export default {
     metamask: '@:metamask',
     confirm: '@:confirmTransactionText',
     newTransaction: 'Create new transaction',
-    changeNetwork: '@:changeNetworkText'
+    changeNetwork: '@:changeNetworkText',
+    connectWallet: '@:connectWalletText'
   },
   // TODO: Add moment.js (it has translation and formatting)
   months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],

--- a/src/store/bridge.ts
+++ b/src/store/bridge.ts
@@ -464,6 +464,11 @@ const actions = {
       }
       const symbol = getters.asset.symbol
       const ethAccount = rootGetters['web3/ethAddress']
+      const connectedExternalAccount = await web3Util.getAccount()
+      if (!connectedExternalAccount || ethAccount.toLowerCase() !== connectedExternalAccount.toLowerCase()) {
+        await dispatch('web3/disconnectExternalAccount', {}, { root: true })
+        throw new Error('Connect account in Metamask')
+      }
       const isValOrXor = [KnownBridgeAsset.XOR, KnownBridgeAsset.VAL].includes(symbol)
       let contract: any = null
       if (isValOrXor) {
@@ -563,6 +568,11 @@ const actions = {
       let contractInstance: any = null
       const contract = rootGetters[`web3/contract${KnownBridgeAsset.Other}`]
       const ethAccount = rootGetters['web3/ethAddress']
+      const connectedExternalAccount = await web3Util.getAccount()
+      if (!connectedExternalAccount || ethAccount.toLowerCase() !== connectedExternalAccount.toLowerCase()) {
+        await dispatch('web3/disconnectExternalAccount', {}, { root: true })
+        throw new Error('Connect account in Metamask')
+      }
       const web3 = await web3Util.getInstance()
       const contractAddress = rootGetters[`web3/address${KnownBridgeAsset.Other}`]
       const allowance = await dispatch('web3/getAllowanceByEthAddress', { address: asset.externalAddress }, { root: true })

--- a/src/store/bridge.ts
+++ b/src/store/bridge.ts
@@ -464,8 +464,8 @@ const actions = {
       }
       const symbol = getters.asset.symbol
       const ethAccount = rootGetters['web3/ethAddress']
-      const connectedExternalAccount = await web3Util.getAccount()
-      if (!connectedExternalAccount || ethAccount.toLowerCase() !== connectedExternalAccount.toLowerCase()) {
+      const isExternalAccountConnected = await web3Util.checkAccountIsConnected(ethAccount)
+      if (!isExternalAccountConnected) {
         await dispatch('web3/disconnectExternalAccount', {}, { root: true })
         throw new Error('Connect account in Metamask')
       }
@@ -568,8 +568,8 @@ const actions = {
       let contractInstance: any = null
       const contract = rootGetters[`web3/contract${KnownBridgeAsset.Other}`]
       const ethAccount = rootGetters['web3/ethAddress']
-      const connectedExternalAccount = await web3Util.getAccount()
-      if (!connectedExternalAccount || ethAccount.toLowerCase() !== connectedExternalAccount.toLowerCase()) {
+      const isExternalAccountConnected = await web3Util.checkAccountIsConnected(ethAccount)
+      if (!isExternalAccountConnected) {
         await dispatch('web3/disconnectExternalAccount', {}, { root: true })
         throw new Error('Connect account in Metamask')
       }

--- a/src/store/web3.ts
+++ b/src/store/web3.ts
@@ -95,8 +95,8 @@ const getters = {
 
 const mutations = {
   [types.RESET] (state) {
-    // we shouldn't reset networks, setted from env
-    const networkSettingsKeys = ['soraNetwork', 'defaultEthNetwork']
+    // we shouldn't reset networks, setted from env & contracts
+    const networkSettingsKeys = ['soraNetwork', 'defaultEthNetwork', 'contractAddress', 'smartContracts']
     const s = initialState()
 
     Object.keys(s).filter(key => !networkSettingsKeys.includes(key)).forEach(key => {

--- a/src/utils/web3-util.ts
+++ b/src/utils/web3-util.ts
@@ -166,7 +166,11 @@ async function onConnectWallet (url = 'https://cloudflare-eth.com'): Promise<str
 async function getAccount (): Promise<string> {
   try {
     const web3Instance = await getInstance()
-    const accounts = await web3Instance.eth.getAccounts()
+    let accounts = await web3Instance.eth.getAccounts()
+
+    if (!Array.isArray(accounts) || !accounts.length) {
+      accounts = await web3Instance.eth.requestAccounts()
+    }
 
     return accounts.length ? accounts[0] : ''
   } catch (error) {

--- a/src/utils/web3-util.ts
+++ b/src/utils/web3-util.ts
@@ -182,6 +182,7 @@ async function checkAccountIsConnected (address: string): Promise<boolean> {
 
   const currentAccount = await getAccount()
 
+  // TODO: check why sometimes currentAccount !== address with the same account
   return !!currentAccount && currentAccount.toLowerCase() === address.toLowerCase()
 }
 

--- a/src/utils/web3-util.ts
+++ b/src/utils/web3-util.ts
@@ -175,6 +175,16 @@ async function getAccount (): Promise<string> {
   }
 }
 
+// TODO: remove this check, when MetaMask issue will be resolved
+// https://github.com/MetaMask/metamask-extension/issues/10368
+async function checkAccountIsConnected (address: string): Promise<boolean> {
+  if (!address) return false
+
+  const currentAccount = await getAccount()
+
+  return !!currentAccount && currentAccount.toLowerCase() === address.toLowerCase()
+}
+
 async function getInstance (): Promise<Web3> {
   if (!provider) {
     provider = await detectEthereumProvider() as any
@@ -292,6 +302,7 @@ async function executeContractMethod ({
 export default {
   onConnect,
   getAccount,
+  checkAccountIsConnected,
   storeEthUserAddress,
   getEthUserAddress,
   storeEthNetwork,

--- a/src/utils/web3-util.ts
+++ b/src/utils/web3-util.ts
@@ -166,11 +166,7 @@ async function onConnectWallet (url = 'https://cloudflare-eth.com'): Promise<str
 async function getAccount (): Promise<string> {
   try {
     const web3Instance = await getInstance()
-    let accounts = await web3Instance.eth.getAccounts()
-
-    if (!Array.isArray(accounts) || !accounts.length) {
-      accounts = await web3Instance.eth.requestAccounts()
-    }
+    const accounts = await web3Instance.eth.getAccounts()
 
     return accounts.length ? accounts[0] : ''
   } catch (error) {

--- a/src/views/Bridge.vue
+++ b/src/views/Bridge.vue
@@ -487,11 +487,9 @@ export default class Bridge extends Mixins(
   }
 
   async handleConfirmTransaction (): Promise<void> {
-    const accountIsConnected = await this.checkExternalAccountIsConnected()
-
-    if (!accountIsConnected) return
-
-    this.showConfirmTransactionDialog = true
+    await this.checkConnectionToExternalAccount(() => {
+      this.showConfirmTransactionDialog = true
+    })
   }
 
   handleViewTransactionsHistory (): void {
@@ -516,11 +514,9 @@ export default class Bridge extends Mixins(
   async confirmTransaction (isTransactionConfirmed: boolean): Promise<void> {
     if (!isTransactionConfirmed) return
 
-    const accountIsConnected = await this.checkExternalAccountIsConnected()
-
-    if (!accountIsConnected) return
-
-    router.push({ name: PageNames.BridgeTransaction })
+    await this.checkConnectionToExternalAccount(() => {
+      router.push({ name: PageNames.BridgeTransaction })
+    })
   }
 }
 </script>

--- a/src/views/BridgeTransaction.vue
+++ b/src/views/BridgeTransaction.vue
@@ -515,14 +515,6 @@ export default class BridgeTransaction extends Mixins(WalletConnectMixin, Loadin
     return `${date.getDate()} ${this.t(`months[${date.getMonth()}]`)} ${date.getFullYear()}, ${formatDateItem(date.getHours())}:${formatDateItem(date.getMinutes())}:${formatDateItem(date.getSeconds())}`
   }
 
-  async checkConnectionToExternalAccount (func): Promise<void> {
-    if (!this.isExternalAccountConnected) {
-      await this.connectExternalWallet()
-    } else {
-      func()
-    }
-  }
-
   async handleSendTransactionFrom (): Promise<void> {
     await this.checkConnectionToExternalAccount(() => {
       if (this.isTransactionFromFailed) {

--- a/src/views/BridgeTransaction.vue
+++ b/src/views/BridgeTransaction.vue
@@ -27,7 +27,7 @@
               </div>
             </template>
             <div v-if="transactionFromHash" :class="hashContainerClasses(!isSoraToEthereum)">
-              <s-input :placeholder="t('bridgeTransaction.transactionHash')" :value="formatAddress(transactionFromHash)" readonly />
+              <s-input :placeholder="t('bridgeTransaction.transactionHash')" :value="formatAddress(transactionFromHash, 32)" readonly />
               <s-button class="s-button--hash-copy" type="link" icon="copy-16" @click="handleCopyTransactionHash(transactionFromHash)" />
               <!-- TODO: Add work with Polkascan -->
               <s-dropdown
@@ -82,7 +82,7 @@
               </div>
             </template>
             <div v-if="isTransactionStep2 && transactionToHash" :class="hashContainerClasses(isSoraToEthereum)">
-              <s-input :placeholder="t('bridgeTransaction.transactionHash')" :value="formatAddress(transactionToHash)" readonly />
+              <s-input :placeholder="t('bridgeTransaction.transactionHash')" :value="formatAddress(transactionToHash, 32)" readonly />
               <s-button class="s-button--hash-copy" type="link" icon="copy-16" @click="handleCopyTransactionHash(transactionToHash)" />
               <s-dropdown
                 v-if="isSoraToEthereum"
@@ -156,7 +156,7 @@ import LoadingMixin from '@/components/mixins/LoadingMixin'
 import NumberFormatterMixin from '@/components/mixins/NumberFormatterMixin'
 import router, { lazyComponent } from '@/router'
 import { Components, PageNames, EthSymbol } from '@/consts'
-import { formatAddress, formatAssetSymbol, copyToClipboard, formatDateItem } from '@/utils'
+import { formatAssetSymbol, copyToClipboard, formatDateItem } from '@/utils'
 import { createFSM, EVENTS, SORA_ETHEREUM_STATES, ETHEREUM_SORA_STATES, STATES } from '@/utils/fsm'
 
 const namespace = 'bridge'
@@ -500,10 +500,6 @@ export default class BridgeTransaction extends Mixins(WalletConnectMixin, Loadin
         title: ''
       })
     }
-  }
-
-  formatAddress (address: string): string {
-    return formatAddress(address, 32)
   }
 
   failedClass (isSecondTransaction: boolean): string {

--- a/src/views/Rewards.vue
+++ b/src/views/Rewards.vue
@@ -276,9 +276,9 @@ export default class Rewards extends Mixins(WalletConnectMixin, TransactionMixin
   }
 
   private async claimRewardsProcess (): Promise<void> {
-    const isConnected = await this.checkExternalAccountIsConnected()
     const internalAddress = this.getWalletAddress()
     const externalAddress = this.ethAddress
+    const isConnected = await web3Util.checkAccountIsConnected(externalAddress)
 
     if (isConnected && internalAddress) {
       await this.withNotifications(


### PR DESCRIPTION
# Task

[PSS-539]: Ethereum bridge. Ethereum transaction failes if Metamask is logged out.

## Changes

1. Added checks during transaction actions run that external account is connected
2. Not reset smart contracts after account disconnect

## Author

Signed-off-by: Nikita-Polyakov <polyakov@soramitsu.co.jp>

[PSS-539]: https://soramitsu.atlassian.net/browse/PSS-539