### PR TITLE
PSS-675: Web UI: Send. Token symbol slides out of the border in case of large precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@metamask/detect-provider": "^1.2.0",
-    "@soramitsu/soraneo-wallet-web": "^0.8.7",
+    "@soramitsu/soraneo-wallet-web": "^0.8.9",
     "@walletconnect/web3-provider": "^1.3.3",
     "axios": "^0.19.2",
     "core-js": "^3.6.4",

--- a/src/components/ConfirmBridgeTransactionDialog.vue
+++ b/src/components/ConfirmBridgeTransactionDialog.vue
@@ -98,7 +98,7 @@ export default class ConfirmBridgeTransactionDialog extends Mixins(TranslationMi
   formatAssetSymbol = formatAssetSymbol
 
   get formattedAmount (): string {
-    return this.getFPNumber(this.amount, this.asset?.decimals).format()
+    return this.formatStringValue(this.amount, this.asset?.decimals)
   }
 
   get assetsClasses (): string {

--- a/src/components/ConfirmBridgeTransactionDialog.vue
+++ b/src/components/ConfirmBridgeTransactionDialog.vue
@@ -5,7 +5,7 @@
   >
     <div :class="assetsClasses">
       <div class="tokens-info-container">
-        <span class="token-value">{{ amount }}</span>
+        <span class="token-value">{{ formattedAmount }}</span>
         <div v-if="asset" class="token">
           <token-logo :token="asset" />
           {{ formatAssetSymbol(asset.symbol) }}
@@ -13,7 +13,7 @@
       </div>
       <s-icon class="icon-divider" name="arrows-arrow-bottom-24" />
       <div class="tokens-info-container">
-        <span class="token-value">{{ amount }}</span>
+        <span class="token-value">{{ formattedAmount }}</span>
         <div v-if="asset" class="token token-ethereum">
           <token-logo :token="asset" />
           {{ formatAssetSymbol(asset.symbol, true) }}
@@ -96,6 +96,10 @@ export default class ConfirmBridgeTransactionDialog extends Mixins(TranslationMi
   EthSymbol = EthSymbol
   KnownSymbols = KnownSymbols
   formatAssetSymbol = formatAssetSymbol
+
+  get formattedAmount (): string {
+    return this.getFPNumber(this.amount, this.asset?.decimals).format()
+  }
 
   get assetsClasses (): string {
     const assetsClass = 'tokens'

--- a/src/components/ConfirmSwap.vue
+++ b/src/components/ConfirmSwap.vue
@@ -71,11 +71,11 @@ export default class ConfirmSwap extends Mixins(TransactionMixin, DialogMixin) {
   @Prop({ default: false, type: Boolean }) readonly isInsufficientBalance!: boolean
 
   get formattedFromValue (): string {
-    return this.getFPNumber(this.fromValue, this.tokenFrom?.decimals).format()
+    return this.formatStringValue(this.fromValue, this.tokenFrom?.decimals)
   }
 
   get formattedToValue (): string {
-    return this.getFPNumber(this.toValue, this.tokenTo?.decimals).format()
+    return this.formatStringValue(this.toValue, this.tokenTo?.decimals)
   }
 
   get formattedMinMaxReceived (): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,10 +2566,10 @@
     vuex "^3.1.3"
     vuex-class "^0.3.2"
 
-"@soramitsu/soraneo-wallet-web@^0.8.7":
-  version "0.8.7"
-  resolved "https://nexus.iroha.tech/repository/npm-group/@soramitsu/soraneo-wallet-web/-/soraneo-wallet-web-0.8.7.tgz#e007302331ea386c4dc8ff2d10fe84913508bec6"
-  integrity sha512-1rwlu7HpsX+lID2Qu34Bs5afxgLdyXEeSK2AxgEbclTKTFDhcsqHMfkaPKMV+pCC/d0UKwf+SlnEbGzMYy0TIw==
+"@soramitsu/soraneo-wallet-web@^0.8.9":
+  version "0.8.9"
+  resolved "https://nexus.iroha.tech/repository/npm-group/@soramitsu/soraneo-wallet-web/-/soraneo-wallet-web-0.8.9.tgz#bcad612d31f68f19719dab37f93435eb46bc5fb4"
+  integrity sha512-aBzmoXq4INiLO179O5aaBZyTGxwTQGoL4LbPFy6CWLFVyBkP6fhwTqaeglEEJdcANmWNyEYskwnRZUVijiaqJQ==
   dependencies:
     "@polkadot/extension-dapp" "^0.35.0-beta.35"
     "@polkadot/vue-identicon" "^0.72.1"


### PR DESCRIPTION
# Task

[PSS-675]: Web UI: Send. Token symbol slides out of the border in case of large precision

## Changes

* Bridge: Formatted amounts for Confirm dialog.

## Author

Signed-off-by: alexnatalia <alekseenko@soramitsu.co.jp>

[PSS-675]: https://soramitsu.atlassian.net/browse/PSS-675