### PR TITLE
PSS-587: Fix icon font content using css-unicode-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@vue/eslint-config-standard": "^5.1.2",
     "@vue/eslint-config-typescript": "^5.0.2",
     "@vue/test-utils": "^1.0.3",
+    "css-unicode-loader": "^1.0.3",
     "eslint": "^6.7.2",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-node": "^11.1.0",

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,6 +1,15 @@
 module.exports = {
-  configureWebpack: {
-    devtool: 'source-map' // Mapping for vscode tasks
+  configureWebpack: config => {
+    // prepare icons content to unicode
+    config.module.rules.filter(rule => {
+      return rule.test.toString().indexOf('scss') !== -1
+    })
+      .forEach(rule => {
+        rule.oneOf.forEach(oneOfRule => {
+          oneOfRule.use.splice(oneOfRule.use.indexOf(require.resolve('sass-loader')), 0,
+            { loader: require.resolve('css-unicode-loader') })
+        })
+      })
   },
   css: {
     loaderOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5813,6 +5813,11 @@ css-tree@1.0.0-alpha.39:
     mdn-data "2.0.6"
     source-map "^0.6.1"
 
+css-unicode-loader@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/css-unicode-loader/-/css-unicode-loader-1.0.3.tgz#2420a7fc562b95e7f6811c6275436a328593a97a"
+  integrity sha512-mszxqB0LCBO2ixbaz/tAH17iEAXmytUv0j/YXtPxhOi8D8Teh+mOXqmz+DZRtDil5tFx7ltbgw16dUptEw4jOg==
+
 css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"


### PR DESCRIPTION
# Task

[PSS-587]: WEB UI. Sometimes elements on page can be broken..

## Changes

Sass processor transform unicode chars to utf-8 chars, so in css files we could see icon content a strange symbols. When browser loads css file from cache, sometimes it's uncorrectly parses this icon content (and render this icons using Times New Roman, not soramitsu-icons)
It looks like the correct way is to deliver css files with unicode content as real unicode, as the font-awesome library does

## Author

Signed-off-by: Nikita-Polyakov <polyakov@soramitsu.co.jp>

[PSS-587]: https://soramitsu.atlassian.net/browse/PSS-587