### PR TITLE
PSS-737: Update wallet to sync account state between tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@metamask/detect-provider": "^1.2.0",
-    "@soramitsu/soraneo-wallet-web": "^0.9.8",
+    "@soramitsu/soraneo-wallet-web": "^0.9.9",
     "@walletconnect/web3-provider": "^1.3.3",
     "axios": "^0.19.2",
     "core-js": "^3.6.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
       <s-button class="polkaswap-logo" type="link" @click="goTo(PageNames.Swap)" />
 
       <div class="app-controls s-flex">
-        <branded-tooltip :disabled="accountConnected" popper-class="info-tooltip wallet-tooltip" placement="bottom">
+        <branded-tooltip :disabled="isLoggedIn" popper-class="info-tooltip wallet-tooltip" placement="bottom">
           <div slot="content" class="app-controls__wallet-tooltip">
             {{ t('connectWalletTextTooltip') }}
           </div>
@@ -12,7 +12,7 @@
             <div class="account">
               <div class="account-name">{{ accountInfo }}</div>
               <div class="account-icon">
-                <s-icon v-if="!accountConnected" name="finance-wallet-24" />
+                <s-icon v-if="!isLoggedIn" name="finance-wallet-24" />
                 <WalletAvatar v-else :address="account.address"/>
               </div>
             </div>
@@ -119,7 +119,7 @@ import LoadingMixin from '@/components/mixins/LoadingMixin'
 
 import router, { lazyComponent } from '@/router'
 import axios from '@/api'
-import { formatAddress, isWalletConnected } from '@/utils'
+import { formatAddress } from '@/utils'
 
 const WALLET_DEFAULT_ROUTE = WALLET_CONSTS.RouteNames.Wallet
 const WALLET_CONNECTION_ROUTE = WALLET_CONSTS.RouteNames.WalletConnection
@@ -148,6 +148,7 @@ export default class App extends Mixins(TransactionMixin, LoadingMixin) {
   showHelpDialog = false
 
   @Getter firstReadyTransaction!: any
+  @Getter isLoggedIn!: boolean
   @Getter account!: any
   @Getter currentRoute!: WALLET_CONSTS.RouteNames
   @Getter faucetUrl!: string
@@ -191,12 +192,8 @@ export default class App extends Mixins(TransactionMixin, LoadingMixin) {
     this.handleChangeTransaction(value)
   }
 
-  get accountConnected (): boolean {
-    return !!this.account.address
-  }
-
   get accountInfo (): string {
-    if (!this.accountConnected) {
+    if (!this.isLoggedIn) {
       return this.t('connectWalletText')
     }
     return this.account.name || formatAddress(this.account.address, 8)
@@ -214,7 +211,7 @@ export default class App extends Mixins(TransactionMixin, LoadingMixin) {
 
   goTo (name: PageNames): void {
     if (name === PageNames.Wallet) {
-      if (!isWalletConnected()) {
+      if (!this.isLoggedIn) {
         this.navigate({ name: WALLET_CONNECTION_ROUTE })
       } else if (this.currentRoute !== WALLET_DEFAULT_ROUTE) {
         this.navigate({ name: WALLET_DEFAULT_ROUTE })

--- a/src/components/SwapInfo.vue
+++ b/src/components/SwapInfo.vue
@@ -20,7 +20,7 @@
     />
     <!-- TODO 4 alexnatalia: Show if logged in and have info about Network Fee -->
     <info-line
-      v-if="connected"
+      v-if="isLoggedIn"
       :label="t('swap.networkFee')"
       :tooltip-content="t('swap.networkFeeTooltip')"
       :value="formattedNetworkFee"
@@ -30,13 +30,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop } from 'vue-property-decorator'
-import { Action, Getter } from 'vuex-class'
+import { Component, Mixins } from 'vue-property-decorator'
+import { Getter } from 'vuex-class'
 import { KnownSymbols, CodecString, AccountAsset } from '@sora-substrate/util'
 
 import TranslationMixin from '@/components/mixins/TranslationMixin'
 import NumberFormatterMixin from '@/components/mixins/NumberFormatterMixin'
-import { isWalletConnected } from '@/utils'
 import { lazyComponent } from '@/router'
 import { Components } from '@/consts'
 
@@ -57,10 +56,7 @@ export default class SwapInfo extends Mixins(TranslationMixin, NumberFormatterMi
 
   @Getter('price', { namespace: 'prices' }) price!: string
   @Getter('priceReversed', { namespace: 'prices' }) priceReversed!: string
-
-  get connected (): boolean {
-    return isWalletConnected()
-  }
+  @Getter isLoggedIn!: boolean
 
   get priceValues (): Array<object> {
     const fromSymbol = this.tokenFrom?.symbol ?? ''

--- a/src/components/mixins/WalletConnectMixin.ts
+++ b/src/components/mixins/WalletConnectMixin.ts
@@ -2,7 +2,7 @@ import { Component, Mixins } from 'vue-property-decorator'
 import { Action, Getter, State } from 'vuex-class'
 
 import router from '@/router'
-import { isWalletConnected, getWalletAddress, formatAddress } from '@/utils'
+import { getWalletAddress, formatAddress } from '@/utils'
 import { PageNames } from '@/consts'
 import web3Util, { Provider } from '@/utils/web3-util'
 
@@ -12,6 +12,7 @@ import TranslationMixin from '@/components/mixins/TranslationMixin'
 export default class WalletConnectMixin extends Mixins(TranslationMixin) {
   @State(state => state.web3.ethAddress) ethAddress!: string
 
+  @Getter('isLoggedIn') isSoraAccountConnected!: boolean
   @Getter('isExternalAccountConnected', { namespace: 'web3' }) isExternalAccountConnected!: boolean
 
   @Action('setEthNetwork', { namespace: 'web3' }) setEthNetwork!: (network?: string) => Promise<void>
@@ -23,10 +24,6 @@ export default class WalletConnectMixin extends Mixins(TranslationMixin) {
   formatAddress = formatAddress
 
   isExternalWalletConnecting = false
-
-  get isSoraAccountConnected (): boolean {
-    return isWalletConnected()
-  }
 
   get areNetworksConnected (): boolean {
     return this.isSoraAccountConnected && this.isExternalAccountConnected

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,7 +2,6 @@ import Vue from 'vue'
 import VueRouter, { RouteConfig } from 'vue-router'
 
 import { PageNames, BridgeChildPages } from '@/consts'
-import { isWalletConnected } from '@/utils'
 import store from '@/store'
 
 Vue.use(VueRouter)
@@ -105,11 +104,11 @@ const router = new VueRouter({
 
 router.beforeEach((to, from, next) => {
   if (to.matched.some(record => record.meta.requiresAuth)) {
-    if (BridgeChildPages.includes(to.name as PageNames) && isWalletConnected() && !store.getters['web3/isExternalAccountConnected']) {
+    if (BridgeChildPages.includes(to.name as PageNames) && store.getters.isLoggedIn && !store.getters['web3/isExternalAccountConnected']) {
       next({ name: PageNames.Bridge })
       return
     }
-    if (!isWalletConnected()) {
+    if (!store.getters.isLoggedIn) {
       next({ name: PageNames.Wallet })
       return
     }

--- a/src/store/pool.ts
+++ b/src/store/pool.ts
@@ -4,8 +4,6 @@ import fromPairs from 'lodash/fp/fromPairs'
 import flow from 'lodash/fp/flow'
 import { api } from '@soramitsu/soraneo-wallet-web'
 
-import { isWalletConnected } from '@/utils'
-
 const types = flow(
   flatMap(x => [x + '_REQUEST', x + '_SUCCESS', x + '_FAILURE']),
   map(x => [x, x]),
@@ -59,8 +57,8 @@ const mutations = {
 }
 
 const actions = {
-  async getAccountLiquidity ({ commit }) {
-    if (!isWalletConnected()) {
+  async getAccountLiquidity ({ commit, rootGetters }) {
+    if (!rootGetters.isLoggedIn) {
       return
     }
     commit(types.GET_ACCOUNT_LIQUIDITY_REQUEST)
@@ -71,13 +69,13 @@ const actions = {
       commit(types.GET_ACCOUNT_LIQUIDITY_FAILURE)
     }
   },
-  async updateAccountLiquidity ({ commit }) {
+  async updateAccountLiquidity ({ commit, rootGetters }) {
     if (updateLiquidityIntervalId) {
       clearInterval(updateLiquidityIntervalId)
     }
     const fiveSeconds = 5 * 1000
     updateLiquidityIntervalId = setInterval(async () => {
-      if (!isWalletConnected()) {
+      if (!rootGetters.isLoggedIn) {
         return
       }
       commit(types.UPDATE_ACCOUNT_LIQUIDITY_REQUEST)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,7 +28,6 @@ export const isMaxButtonAvailable = (
   parseAsLiquidity = false
 ): boolean => {
   if (
-    !isWalletConnected() ||
     !asset ||
     !areAssetsSelected ||
     !fee ||
@@ -101,16 +100,6 @@ export const hasInsufficientEthForFee = (ethBalance: string, fee: string): boole
 
 export const getWalletAddress = (): string => {
   return storage.get('address')
-}
-
-export const isWalletConnected = (): boolean => {
-  const isExternal = Boolean(storage.get('isExternal'))
-  const address = getWalletAddress()
-  return !!(
-    isExternal
-      ? address
-      : address && storage.get('name') && storage.get('password')
-  )
 }
 
 export async function delay (ms = 50): Promise<void> {

--- a/src/views/AddLiquidity.vue
+++ b/src/views/AddLiquidity.vue
@@ -8,7 +8,7 @@
       <div class="input-container">
         <div class="input-line-header">
           <div class="input-title p4">{{ t('createPair.deposit') }}</div>
-          <div v-if="connected && firstToken" class="token-balance">
+          <div v-if="isLoggedIn && firstToken" class="token-balance">
             <span class="token-balance-title">{{ t('createPair.balance') }}</span>
             <span class="token-balance-value">{{ getTokenBalance(firstToken) }}</span>
           </div>
@@ -42,7 +42,7 @@
           <div class="input-title p4">
             <span>{{ t('createPair.deposit') }}</span>
           </div>
-          <div v-if="connected && secondToken" class="token-balance">
+          <div v-if="isLoggedIn && secondToken" class="token-balance">
             <span class="token-balance-title">{{ t('exchange.balance') }}</span>
             <span class="token-balance-value">{{ getTokenBalance(secondToken) }}</span>
           </div>
@@ -132,8 +132,8 @@
       <info-line :label="secondToken.symbol" :value="secondTokenPosition" />
     </div>
 
-    <select-token :visible.sync="showSelectFirstTokenDialog" :connected="connected" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstTokenAddress($event.address)" />
-    <select-token :visible.sync="showSelectSecondTokenDialog" :connected="connected" :asset="firstToken" @select="setSecondTokenAddress($event.address)" />
+    <select-token :visible.sync="showSelectFirstTokenDialog" :connected="isLoggedIn" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstTokenAddress($event.address)" />
+    <select-token :visible.sync="showSelectSecondTokenDialog" :connected="isLoggedIn" :asset="firstToken" @select="setSecondTokenAddress($event.address)" />
 
     <confirm-token-pair-dialog
       :visible.sync="showConfirmDialog"

--- a/src/views/CreatePair.vue
+++ b/src/views/CreatePair.vue
@@ -8,7 +8,7 @@
       <div class="input-container">
         <div class="input-line-header">
           <div class="input-title p4">{{ t('createPair.deposit') }}</div>
-          <div v-if="connected && firstToken" class="token-balance">
+          <div v-if="isLoggedIn && firstToken" class="token-balance">
             <span class="token-balance-title">{{ t('createPair.balance') }}</span>
             <span class="token-balance-value">{{ getTokenBalance(firstToken) }}</span>
           </div>
@@ -42,7 +42,7 @@
           <div class="input-title p4">
             <span>{{ t('createPair.deposit') }}</span>
           </div>
-          <div v-if="connected && secondToken" class="token-balance">
+          <div v-if="isLoggedIn && secondToken" class="token-balance">
             <span class="token-balance-title">{{ t('exchange.balance') }}</span>
             <span class="token-balance-value">{{ getTokenBalance(secondToken) }}</span>
           </div>
@@ -127,8 +127,8 @@
       </template>
     </template>
 
-    <select-token :visible.sync="showSelectFirstTokenDialog" :connected="connected" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstTokenAddress($event.address)" />
-    <select-token :visible.sync="showSelectSecondTokenDialog" :connected="connected" :asset="firstToken" @select="setSecondTokenAddress($event.address)" />
+    <select-token :visible.sync="showSelectFirstTokenDialog" :connected="isLoggedIn" account-assets-only not-null-balance-only :asset="secondToken" @select="setFirstTokenAddress($event.address)" />
+    <select-token :visible.sync="showSelectSecondTokenDialog" :connected="isLoggedIn" :asset="firstToken" @select="setSecondTokenAddress($event.address)" />
 
     <confirm-token-pair-dialog
       :visible.sync="showConfirmDialog"

--- a/src/views/Pool.vue
+++ b/src/views/Pool.vue
@@ -2,7 +2,7 @@
   <div v-loading="parentLoading" class="container el-form--pool">
     <generic-page-header class="page-header--pool" :title="t('exchange.Pool')" :tooltip="t('pool.description')" />
     <div class="pool-wrapper" v-loading="loading">
-      <p v-if="!connected" class="pool-info-container">
+      <p v-if="!isLoggedIn" class="pool-info-container">
         {{ t('pool.connectToWallet') }}
       </p>
       <p v-else-if="!accountLiquidity || !accountLiquidity.length" class="pool-info-container">
@@ -46,7 +46,7 @@
         </s-collapse-item>
       </s-collapse>
     </div>
-    <template v-if="connected">
+    <template v-if="isLoggedIn">
       <s-button class="el-button--add-liquidity" type="primary" @click="handleAddLiquidity">
         {{ t('pool.addLiquidity') }}
       </s-button>
@@ -68,7 +68,6 @@ import { AccountLiquidity } from '@sora-substrate/util'
 import TranslationMixin from '@/components/mixins/TranslationMixin'
 import LoadingMixin from '@/components/mixins/LoadingMixin'
 import NumberFormatterMixin from '@/components/mixins/NumberFormatterMixin'
-import { isWalletConnected } from '@/utils'
 import router, { lazyComponent } from '@/router'
 import { Components, PageNames } from '@/consts'
 
@@ -82,6 +81,7 @@ const namespace = 'pool'
   }
 })
 export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberFormatterMixin) {
+  @Getter isLoggedIn!: boolean
   @Getter('accountLiquidity', { namespace }) accountLiquidity!: any
   @Getter('assets', { namespace: 'assets' }) assets
 
@@ -95,10 +95,6 @@ export default class Pool extends Mixins(TranslationMixin, LoadingMixin, NumberF
       await this.getAssets()
       await this.getAccountLiquidity()
     })
-  }
-
-  get connected (): boolean {
-    return isWalletConnected()
   }
 
   getAsset (address): any {

--- a/src/views/RemoveLiquidity.vue
+++ b/src/views/RemoveLiquidity.vue
@@ -26,7 +26,7 @@
       <div class="input-container">
         <div class="input-line-header">
           <div class="input-title p4">{{ t('removeLiquidity.input') }}</div>
-          <div v-if="isWalletConnected && liquidity" class="token-balance">
+          <div v-if="liquidity" class="token-balance">
             <span class="token-balance-title">{{ t('createPair.balance') }}</span>
             <span class="token-balance-value">{{ getFormattedLiquidityBalance(liquidity) }}</span>
           </div>
@@ -63,7 +63,7 @@
       <div class="input-container">
         <div class="input-line-header">
           <div class="input-title p4">{{ t('removeLiquidity.output') }}</div>
-          <div v-if="isWalletConnected && liquidity" class="token-balance">-</div>
+          <div v-if="liquidity" class="token-balance">-</div>
         </div>
         <div class="input-line-content">
           <s-form-item>
@@ -92,7 +92,7 @@
       <div class="input-container">
         <div class="input-line-header">
           <div class="input-title p4">{{ t('removeLiquidity.output') }}</div>
-          <div v-if="isWalletConnected && liquidity" class="token-balance">-</div>
+          <div v-if="liquidity" class="token-balance">-</div>
         </div>
         <div class="input-line-content">
           <s-form-item>
@@ -247,8 +247,6 @@ export default class RemoveLiquidity extends Mixins(TransactionMixin, LoadingMix
       this.$el.removeEventListener('mousedown', this.sliderDragButton)
     }
   }
-
-  isWalletConnected = true
 
   get firstTokenAddress (): string {
     return this.$route.params.firstAddress

--- a/src/views/Rewards.vue
+++ b/src/views/Rewards.vue
@@ -37,7 +37,7 @@
     <s-button v-if="!rewardsRecieved" class="rewards-block rewards-action-button" type="primary" @click="handleAction" :loading="actionButtonLoading" :disabled="actionButtonDisabled">
       {{ actionButtonText }}
     </s-button>
-    <info-line v-if="fee && rewardsAvailable && !claimingInProgressOrFinished" v-bind="feeInfo" class="rewards-block" />
+    <info-line v-if="fee && areNetworksConnected && rewardsAvailable && !claimingInProgressOrFinished" v-bind="feeInfo" class="rewards-block" />
   </div>
 </template>
 

--- a/src/views/Swap.vue
+++ b/src/views/Swap.vue
@@ -17,7 +17,7 @@
             ({{ t('swap.estimated') }})
           </span>
         </div>
-        <div v-if="this.connected && this.tokenFrom && this.tokenFrom.balance" class="token-balance">
+        <div v-if="isLoggedIn && tokenFrom && tokenFrom.balance" class="token-balance">
           <span class="token-balance-title">{{ t('exchange.balance') }}</span>
           <span class="token-balance-value">{{ formatBalance(tokenFrom) }}</span>
         </div>
@@ -56,7 +56,7 @@
             ({{ t('swap.estimated') }})
           </span>
         </div>
-        <div v-if="this.connected && this.tokenTo && this.tokenTo.balance" class="token-balance">
+        <div v-if="isLoggedIn && tokenTo && tokenTo.balance" class="token-balance">
           <span class="token-balance-title">{{ t('exchange.balance') }}</span>
           <span class="token-balance-value">{{ formatBalance(tokenTo) }}</span>
         </div>
@@ -83,7 +83,7 @@
         </s-button>
       </div>
     </div>
-    <s-button v-if="!connected" type="primary" @click="handleConnectWallet">
+    <s-button v-if="!isLoggedIn" type="primary" @click="handleConnectWallet">
       {{ t('swap.connectWallet') }}
     </s-button>
     <s-button v-else type="primary" :disabled="!areTokensSelected || !isAvailable || hasZeroAmount || isInsufficientLiquidity || isInsufficientAmount || isInsufficientBalance || isInsufficientXorForFee" @click="handleConfirmSwap">
@@ -114,7 +114,7 @@
     </s-button>
     <slippage-tolerance class="slippage-tolerance-settings" />
     <swap-info v-if="areTokensSelected && !hasZeroAmount" class="info-line-container" />
-    <select-token :visible.sync="showSelectTokenDialog" :connected="connected" :asset="isTokenFromSelected ? tokenTo : tokenFrom" @select="selectToken" />
+    <select-token :visible.sync="showSelectTokenDialog" :connected="isLoggedIn" :asset="isTokenFromSelected ? tokenTo : tokenFrom" @select="selectToken" />
     <confirm-swap :visible.sync="showConfirmSwapDialog" :isInsufficientBalance="isInsufficientBalance" @confirm="confirmSwap" />
     <settings-dialog :visible.sync="showSettings" />
   </s-form>
@@ -130,7 +130,7 @@ import TranslationMixin from '@/components/mixins/TranslationMixin'
 import LoadingMixin from '@/components/mixins/LoadingMixin'
 import NumberFormatterMixin from '@/components/mixins/NumberFormatterMixin'
 
-import { isWalletConnected, isMaxButtonAvailable, getMaxValue, hasInsufficientBalance, hasInsufficientXorForFee, asZeroValue, formatAssetBalance } from '@/utils'
+import { isMaxButtonAvailable, getMaxValue, hasInsufficientBalance, hasInsufficientXorForFee, asZeroValue, formatAssetBalance } from '@/utils'
 import router, { lazyComponent } from '@/router'
 import { Components, PageNames } from '@/consts'
 
@@ -173,6 +173,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   @Action('getAssets', { namespace: 'assets' }) getAssets
   @Action('setPairLiquiditySources', { namespace }) setPairLiquiditySources!: (liquiditySources: Array<LiquiditySourceTypes>) => Promise<void>
 
+  @Getter isLoggedIn!: boolean
   @Getter slippageTolerance!: number
   @Getter accountAssets!: Array<AccountAsset> // Wallet store
   @Getter('swapLiquiditySource', { namespace }) liquiditySource!: LiquiditySourceTypes
@@ -188,6 +189,13 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
     this.recountSwapValues()
   }
 
+  @Watch('isLoggedIn')
+  private handleLoggedInStateChange (isLoggedIn: boolean, wasLoggedIn: boolean): void {
+    if (!wasLoggedIn && isLoggedIn) {
+      this.recountSwapValues()
+    }
+  }
+
   @Prop({ type: Boolean, default: false }) readonly parentLoading!: boolean
 
   KnownSymbols = KnownSymbols
@@ -198,10 +206,6 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   showSelectTokenDialog = false
   showConfirmSwapDialog = false
   isRecountingProcess = false
-
-  get connected (): boolean {
-    return isWalletConnected()
-  }
 
   get areTokensSelected (): boolean {
     return !!(this.tokenFrom && this.tokenTo)
@@ -224,11 +228,11 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   }
 
   get isMaxSwapAvailable (): boolean {
-    return isMaxButtonAvailable(this.areTokensSelected, this.tokenFrom, this.fromValue, this.networkFee, this.tokenXOR)
+    return this.isLoggedIn && isMaxButtonAvailable(this.areTokensSelected, this.tokenFrom, this.fromValue, this.networkFee, this.tokenXOR)
   }
 
   get preparedForSwap (): boolean {
-    return this.connected && this.areTokensSelected
+    return this.isLoggedIn && this.areTokensSelected
   }
 
   get isInsufficientLiquidity (): boolean {
@@ -272,7 +276,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   }
 
   async getNetworkFee (): Promise<void> {
-    if (this.connected) {
+    if (this.isLoggedIn) {
       const networkFee = await api.getSwapNetworkFee(
         this.tokenFrom?.address,
         this.tokenTo?.address,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2567,10 +2567,10 @@
     vuex "^3.1.3"
     vuex-class "^0.3.2"
 
-"@soramitsu/soraneo-wallet-web@^0.9.8":
-  version "0.9.8"
-  resolved "https://nexus.iroha.tech/repository/npm-group/@soramitsu/soraneo-wallet-web/-/soraneo-wallet-web-0.9.8.tgz#698c64c5209a1ce9378ddc7bd0366a5825fd6327"
-  integrity sha512-Qz1lHqH4RPxbEaYRAVGLFkqAYRjbbhR02F8Va8IM/kYxhdK5ici4ntZBybxMkVFIbYusHTJnE6C72JgaLXASGA==
+"@soramitsu/soraneo-wallet-web@^0.9.9":
+  version "0.9.9"
+  resolved "https://nexus.iroha.tech/repository/npm-group/@soramitsu/soraneo-wallet-web/-/soraneo-wallet-web-0.9.9.tgz#d3f3f57734cbf26881247a3c3b9ea2bf6877fe24"
+  integrity sha512-UuSokig0b0BWT0i9e/RjVQ8TgtSQWPBDGjZdkz8fCrNRBGxuTwT9Fi1zZp7nf4YK94p1ME+irYES50HLX3zJqw==
   dependencies:
     "@polkadot/extension-dapp" "^0.35.0-beta.35"
     "@polkadot/vue-identicon" "^0.72.1"


### PR DESCRIPTION
# Task

[PSS-737]: WEB UI. Re-login incorrect wallet state.

## Changes

1. Updated wallet to 0.9.9
2. Refactoring components to use `isLoggedIn` getter from wallet, to have a correct reactive view updates

## Author

Signed-off-by: Nikita-Polyakov <polyakov@gmail.com>

[PSS-737]: https://soramitsu.atlassian.net/browse/PSS-737