### PR TITLE
Use web3Instance as singletone

### DIFF
--- a/src/utils/web3-util.ts
+++ b/src/utils/web3-util.ts
@@ -67,6 +67,7 @@ export const ABI = {
 }
 
 let provider: any = null
+let web3Istance: any = null
 
 export enum KnownBridgeAsset {
   VAL = 'VAL',
@@ -147,7 +148,7 @@ async function onConnectMetamask (): Promise<string> {
   if (!provider) {
     throw new Error('providers.metamask')
   }
-  const web3Instance = new Web3(provider)
+  const web3Instance = await getInstance()
   const accounts = await web3Instance.eth.requestAccounts()
   return accounts.length ? accounts[0] : ''
 }
@@ -193,7 +194,10 @@ async function getInstance (): Promise<Web3> {
   if (!provider) {
     throw new Error('No Web3 instance!')
   }
-  return new Web3(provider)
+  if (!web3Istance) {
+    web3Istance = new Web3(provider)
+  }
+  return web3Istance
 }
 
 async function watchEthereum (cb: {
@@ -213,7 +217,9 @@ async function watchEthereum (cb: {
 
   return function disconnect () {
     if (ethereum) {
-      ethereum.removeAllListeners()
+      ethereum.removeListener('accountsChanged', cb.onAccountChange)
+      ethereum.removeListener('chainChanged', cb.onNetworkChange)
+      ethereum.removeListener('disconnect', cb.onDisconnect)
     }
   }
 }


### PR DESCRIPTION
I found that every call `new Web3(provider)` adds the same event listeners to ` window.ethereum`, and this causes the warnings for possible memory leaks of `EventEmitter`
Also added a change, that `watchEthereum` util function return a callback, that removes event listeners added only from our side

Event listeners before changes
![events-before](https://user-images.githubusercontent.com/53777036/114668352-4ef6dd80-9d09-11eb-8cd1-61849ae6a5ae.jpg)

Event listeners after changes
![events-after](https://user-images.githubusercontent.com/53777036/114668402-5e762680-9d09-11eb-947a-447799f914f3.jpg)

