### PR TITLE
add syncExternalAccountWithAppState method

### DIFF
--- a/src/components/mixins/WalletConnectMixin.ts
+++ b/src/components/mixins/WalletConnectMixin.ts
@@ -74,4 +74,18 @@ export default class WalletConnectMixin extends Mixins(TranslationMixin) {
       await func()
     }
   }
+
+  async syncExternalAccountWithAppState () {
+    const connected = await web3Util.checkAccountIsConnected(this.ethAddress)
+
+    if (connected) return
+
+    await this.disconnectExternalAccount()
+
+    const account = await web3Util.getAccount()
+
+    if (account) {
+      await this.changeExternalWallet({ address: account })
+    }
+  }
 }

--- a/src/views/Bridge.vue
+++ b/src/views/Bridge.vue
@@ -357,7 +357,8 @@ export default class Bridge extends Mixins(
   }
 
   async mounted (): Promise<void> {
-    this.setEthNetwork()
+    await this.setEthNetwork()
+    await this.syncExternalAccountWithAppState()
     this.getEthBalance()
     this.resetBridgeForm(!!router.currentRoute.params?.address)
     this.withApi(async () => {

--- a/src/views/Rewards.vue
+++ b/src/views/Rewards.vue
@@ -104,6 +104,7 @@ export default class Rewards extends Mixins(WalletConnectMixin, TransactionMixin
   async mounted (): Promise<void> {
     await this.withApi(async () => {
       await this.setEthNetwork()
+      await this.syncExternalAccountWithAppState()
       await this.checkAccountRewards()
 
       this.unwatchEthereum = await web3Util.watchEthereum({


### PR DESCRIPTION
When user goes to `Bridge `or `Rewards `page, we should check a current external account address - because user could change account using Meatamask extension on another page