### PR TITLE
PSS-801: Show max button if fee is like zero value

### DIFF
--- a/src/store/addLiquidity.ts
+++ b/src/store/addLiquidity.ts
@@ -222,7 +222,10 @@ const actions = {
       commit(types.SET_FOCUSED_FIELD, 'firstTokenValue')
 
       commit(types.SET_FIRST_TOKEN_VALUE, value)
-      if (value && getters.isNotFirstLiquidityProvider) {
+
+      if (!value) {
+        commit(types.SET_SECOND_TOKEN_VALUE, '')
+      } else if (getters.isNotFirstLiquidityProvider) {
         commit(
           types.SET_SECOND_TOKEN_VALUE,
           new FPNumber(value)
@@ -231,6 +234,7 @@ const actions = {
             .toString()
         )
       }
+
       dispatch('estimateMinted')
       dispatch('getNetworkFee')
     }
@@ -241,7 +245,10 @@ const actions = {
       commit(types.SET_FOCUSED_FIELD, 'secondTokenValue')
 
       commit(types.SET_SECOND_TOKEN_VALUE, value)
-      if (value && getters.isNotFirstLiquidityProvider) {
+
+      if (!value) {
+        commit(types.SET_FIRST_TOKEN_VALUE, '')
+      } else if (getters.isNotFirstLiquidityProvider) {
         commit(
           types.SET_FIRST_TOKEN_VALUE,
           new FPNumber(value)
@@ -250,6 +257,7 @@ const actions = {
             .toString()
         )
       }
+
       dispatch('estimateMinted')
       dispatch('getNetworkFee')
     }

--- a/src/store/swap.ts
+++ b/src/store/swap.ts
@@ -21,7 +21,8 @@ const types = flow(
     'SET_PAIR_LIQUIDITY_SOURCES',
     'SET_NETWORK_FEE',
     'SET_REWARDS',
-    'GET_SWAP_CONFIRM'
+    'GET_SWAP_CONFIRM',
+    'RESET'
   ]),
   map(x => [x, x]),
   fromPairs
@@ -101,6 +102,13 @@ const getters = {
 }
 
 const mutations = {
+  [types.RESET] (state: SwapState) {
+    const s = initialState()
+
+    Object.keys(s).forEach(key => {
+      state[key] = s[key]
+    })
+  },
   [types.SET_TOKEN_FROM_ADDRESS] (state: SwapState, address: string) {
     state.tokenFromAddress = address
   },
@@ -227,6 +235,9 @@ const actions = {
   },
   setNetworkFee ({ commit }, networkFee: string) {
     commit(types.SET_NETWORK_FEE, networkFee)
+  },
+  reset ({ commit }) {
+    commit(types.RESET)
   }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,7 +38,6 @@ export const isMaxButtonAvailable = (
   if (
     !asset ||
     !areAssetsSelected ||
-    !fee ||
     !xorAsset ||
     asZeroValue(getAssetBalance(asset, { parseAsLiquidity }))) {
     return false
@@ -97,7 +96,8 @@ export const hasInsufficientBalance = (
 }
 
 export const hasInsufficientXorForFee = (xorAsset: AccountAsset | RegisteredAccountAsset | null, fee: CodecString, isXorOutputSwap = false): boolean => {
-  if (!xorAsset || !fee) return true
+  if (!xorAsset) return true
+  if (asZeroValue(fee)) return false
 
   const decimals = xorAsset.decimals
   const xorBalance = getAssetBalance(xorAsset)
@@ -108,8 +108,11 @@ export const hasInsufficientXorForFee = (xorAsset: AccountAsset | RegisteredAcco
 }
 
 export const hasInsufficientEthForFee = (ethBalance: CodecString, fee: CodecString): boolean => {
+  if (!fee) return false
+
   const fpBalance = FPNumber.fromCodecValue(ethBalance)
   const fpFee = FPNumber.fromCodecValue(fee)
+
   return FPNumber.lt(fpBalance, fpFee)
 }
 

--- a/src/views/Swap.vue
+++ b/src/views/Swap.vue
@@ -254,7 +254,6 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   }
 
   created () {
-    this.reset()
     this.withApi(async () => {
       await this.getAssets()
       if (!this.tokenFrom) {
@@ -268,6 +267,10 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
       }
       await this.updatePairLiquiditySources()
     })
+  }
+
+  destroyed () {
+    this.reset()
   }
 
   formatBalance (token): string {

--- a/src/views/Swap.vue
+++ b/src/views/Swap.vue
@@ -167,6 +167,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   @Action('setLiquidityProviderFee', { namespace }) setLiquidityProviderFee!: (value: CodecString) => Promise<void>
   @Action('setNetworkFee', { namespace }) setNetworkFee!: (value: CodecString) => Promise<void>
   @Action('checkSwap', { namespace }) checkSwap!: () => Promise<void>
+  @Action('reset', { namespace }) reset!: () => void
 
   @Action('getPrices', { namespace: 'prices' }) getPrices!: (options: any) => Promise<void>
   @Action('resetPrices', { namespace: 'prices' }) resetPrices!: () => Promise<void>
@@ -253,6 +254,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
   }
 
   created () {
+    this.reset()
     this.withApi(async () => {
       await this.getAssets()
       if (!this.tokenFrom) {
@@ -260,7 +262,7 @@ export default class Swap extends Mixins(TranslationMixin, LoadingMixin, NumberF
         await this.setTokenFromAddress(xorAddress)
         await this.setTokenToAddress()
       }
-      if (this.tokenFrom && this.tokenTo) {
+      if (this.areTokensSelected) {
         await this.getNetworkFee()
         await this.checkSwap()
       }


### PR DESCRIPTION
# Task

[PSS-801]: WEB UI: Max button isn't shown in SWAP until some amount entered.

## Changes

1. Updated `isMaxButtonAvailable` & related util functions
2. Reset Swap page during `created ` hook
3. Add liquidity - reset opposite field, if focused field is clear

[PSS-801]: https://soramitsu.atlassian.net/browse/PSS-801